### PR TITLE
Fixes closing click in IE and Edge

### DIFF
--- a/dist/draw/handler/Polyline.js
+++ b/dist/draw/handler/Polyline.js
@@ -161,7 +161,7 @@ var Polyline = function (_Feature) {
       this._clearGuides();
 
       // adds click handler to start of this line
-      this._map.off('click', this._onClick, this).off('mouseup', this._onMouseUp, this).off('mousemove', this._onMouseMove, this).off('zoomlevelschange', this._onZoomEnd, this).off('zoomend', this._onZoomEnd, this).off('touchstart', this._onTouch, this).off('click', this._onTouch, this);
+      this._map.off('mouseup', this._onMouseUp, this).off('mousemove', this._onMouseMove, this).off('zoomlevelschange', this._onZoomEnd, this).off('zoomend', this._onZoomEnd, this).off('touchstart', this._onTouch, this).off('click', this._onTouch, this);
     }
   }, {
     key: 'deleteLastVertex',

--- a/dist/draw/handler/Polyline.js
+++ b/dist/draw/handler/Polyline.js
@@ -161,7 +161,7 @@ var Polyline = function (_Feature) {
       this._clearGuides();
 
       // adds click handler to start of this line
-      this._map.off('click', this._onClick, this)_map.off('mouseup', this._onMouseUp, this).off('mousemove', this._onMouseMove, this).off('zoomlevelschange', this._onZoomEnd, this).off('zoomend', this._onZoomEnd, this).off('touchstart', this._onTouch, this).off('click', this._onTouch, this);
+      this._map.off('click', this._onClick, this).off('mouseup', this._onMouseUp, this).off('mousemove', this._onMouseMove, this).off('zoomlevelschange', this._onZoomEnd, this).off('zoomend', this._onZoomEnd, this).off('touchstart', this._onTouch, this).off('click', this._onTouch, this);
     }
   }, {
     key: 'deleteLastVertex',

--- a/dist/draw/handler/Polyline.js
+++ b/dist/draw/handler/Polyline.js
@@ -160,7 +160,8 @@ var Polyline = function (_Feature) {
 
       this._clearGuides();
 
-      this._map.off('mouseup', this._onMouseUp, this).off('mousemove', this._onMouseMove, this).off('zoomlevelschange', this._onZoomEnd, this).off('zoomend', this._onZoomEnd, this).off('touchstart', this._onTouch, this).off('click', this._onTouch, this);
+      // adds click handler to start of this line
+      this._map.off('click', this._onClick, this)_map.off('mouseup', this._onMouseUp, this).off('mousemove', this._onMouseMove, this).off('zoomlevelschange', this._onZoomEnd, this).off('zoomend', this._onZoomEnd, this).off('touchstart', this._onTouch, this).off('click', this._onTouch, this);
     }
   }, {
     key: 'deleteLastVertex',

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2811,7 +2812,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2832,12 +2834,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2852,17 +2856,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2979,7 +2986,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2991,6 +2999,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3005,6 +3014,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3012,12 +3022,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3036,6 +3048,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3116,7 +3129,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3128,6 +3142,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3213,7 +3228,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3249,6 +3265,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3268,6 +3285,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3311,12 +3329,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5072,9 +5092,9 @@
       }
     },
     "leaflet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
-      "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.5.1.tgz",
+      "integrity": "sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w=="
     },
     "left-pad": {
       "version": "1.3.0",
@@ -5137,7 +5157,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src/"
   ],
   "dependencies": {
-    "leaflet": "^1.3.1"
+    "leaflet": "^1.5.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/es6/draw/handler/Polyline.js
+++ b/src/es6/draw/handler/Polyline.js
@@ -188,6 +188,7 @@ export default class Polyline extends Feature {
     this._clearGuides();
 
     this._map
+      .off('click', this._onClick, this)
       .off('mouseup', this._onMouseUp, this)
       .off('mousemove', this._onMouseMove, this)
       .off('zoomlevelschange', this._onZoomEnd, this)


### PR DESCRIPTION
This change cancels the final click event when drawing a polygon if this is used in IE11 or Edge